### PR TITLE
Added Enum to Run Commands

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -7,6 +7,7 @@ package frc.robot;
 import frc.robot.Constants.OperatorConstants;
 import frc.robot.commands.RunAnglerCommand;
 import frc.robot.commands.RunIntakeCommand;
+import frc.robot.commands.RunIntakeCommand.DirectionEnum;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.team5431.titan.core.joysticks.CommandXboxController;
 
@@ -16,16 +17,15 @@ public class RobotContainer {
       new CommandXboxController(OperatorConstants.kDriverControllerPort);
   private final CommandXboxController m_operatorController =
       new CommandXboxController(OperatorConstants.kOperatorControllerPort);
-
   private final Systems systems = new Systems();
-  
+
   public RobotContainer() {
 
   }
 
   private void configureBindings() {
-    m_operatorController.a().whileTrue(new RunIntakeCommand(true, systems.getIntake()));
-    m_operatorController.y().whileTrue(new RunIntakeCommand(false, systems.getIntake()));
+    m_operatorController.a().whileTrue(new RunIntakeCommand(DirectionEnum.INTAKE, systems.getIntake()));
+    m_operatorController.y().whileTrue(new RunIntakeCommand(DirectionEnum.OUTTAKE, systems.getIntake()));
     m_operatorController.b().whileTrue(new RunAnglerCommand(true, systems.getAngler()));
     m_operatorController.x().whileTrue(new RunAnglerCommand(false, systems.getAngler()));
   }

--- a/src/main/java/frc/robot/commands/RunIntakeCommand.java
+++ b/src/main/java/frc/robot/commands/RunIntakeCommand.java
@@ -5,21 +5,26 @@ import frc.robot.subsystems.Intake;
 
 public class RunIntakeCommand extends Command {
     
-    final boolean forward;
+    public final DirectionEnum direction;
     final Intake intake;
 
-    public RunIntakeCommand(boolean forward, Intake intake){
-        this.forward = forward;
+    public enum DirectionEnum{
+        INTAKE,
+        OUTTAKE
+    }
+
+    public RunIntakeCommand(DirectionEnum direction, Intake intake){
+        this.direction = direction;
         this.intake = intake;
     }
     
     @Override
     public void initialize() {
-        if(forward){
+        if(direction == DirectionEnum.INTAKE){
             intake.intake();
             intake.setMode(Intake.Modes.FORWARD);
         }
-        else {
+        else if (direction == DirectionEnum.OUTTAKE) {
             intake.outtake();
             intake.setMode(Intake.Modes.REVERSE);
         }
@@ -28,5 +33,9 @@ public class RunIntakeCommand extends Command {
     @Override
     public void end(boolean interrupted) {
         intake.run(0);
+    }
+
+    public DirectionEnum direction(String string) {
+        throw new UnsupportedOperationException("Unimplemented method 'direction'");
     }
 }


### PR DESCRIPTION
This implementation could enhance the organization and clarity of command-related functionalities. Enums are often used to define a set of named constant values, which could be particularly useful in the context of running commands within a software system. This addition might contribute to better maintainability, as developers can now reference these Enum values when working with commands, potentially improving code readability and reducing the likelihood of errors.